### PR TITLE
Improved error message when failing to take Location as Foi

### DIFF
--- a/sensorthings/api/observation.go
+++ b/sensorthings/api/observation.go
@@ -111,8 +111,8 @@ func (a *APIv1) PostObservation(observation *entities.Observation) (*entities.Ob
 		foiID, err := CopyLocationToFoi(&a.db, datastreamID)
 
 		if err != nil {
-			errorMessage := "Unable to copy location of thing to featureofinterest."
-			return nil, []error{gostErrors.NewBadRequestError(errors.New(errorMessage))}
+			errorMessage := "Missing Observation.FeatureOfInterest. Unable to create it from the Location: "
+			return nil, []error{gostErrors.NewBadRequestError(errors.New(errorMessage+err.Error()))}
 		}
 
 		observation.FeatureOfInterest = &entities.FeatureOfInterest{}


### PR DESCRIPTION
Hi,

I understand that this features is described in the standard as:
> In the case of creating an Observation whose FeatureOfInterest is the Thing’s Location (that means the Thing entity has a related Location entity), the request of creating the Observation SHOULD NOT include a link to a FeatureOfInterest entity. The service will first automatically create a FeatureOfInterest entity from the Location of the Thing and then link to the Observation. <sup>[1](http://docs.opengeospatial.org/is/15-078r6/15-078r6.html#62)</sup>

But the error message didn't provide enough context. Also, the code ignored the error message returned from `CopyLocationToFoi`.  Please update the error message as you see fit.