### PR TITLE
More MQTT configuration options and switch to paho.mqtt.golang 1.1.1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,15 +10,15 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:eecb3e6cef98036972582ffff7d3e340aef15f075236da353aa3e7fb798fdb21"
+  digest = "1:3fa846cb3feb4e65371fe3c347c299de9b5bc3e71e256c0d940cd19b767a6ba0"
   name = "github.com/eclipse/paho.mqtt.golang"
   packages = [
     ".",
     "packets",
   ]
   pruneopts = ""
-  revision = "aff15770515e3c57fc6109da73d42b0d46f7f483"
-  version = "v1.1.0"
+  revision = "36d01c2b4cbeb3d2a12063e4880ce30800af9560"
+  version = "v1.1.1"
 
 [[projects]]
   digest = "1:20ed7daa9b3b38b6d1d39b48ab3fd31122be5419461470d0c28de3e121c93ecf"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/eclipse/paho.mqtt.golang"
-  version = "1.1.0"
+  version = "1.1.1"
 
 [[constraint]]
   name = "github.com/gorilla/mux"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/eclipse/paho.mqtt.golang"
-  version = "1.1.1"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/gorilla/mux"

--- a/config.yaml
+++ b/config.yaml
@@ -20,12 +20,14 @@ database:
     maxOpenConns: 100
 mqtt:
     enabled: true
+    verbose: false
     host: localhost
     port: 1883
     prefix: GOST
     clientId: gost
     subscriptionQos: 1
     persistent: true
+    order: true
     ssl: false
     caCertFile:
     clientCertFile:

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -45,12 +45,14 @@ type DatabaseConfig struct {
 // MQTTConfig contains the MQTT client information
 type MQTTConfig struct {
 	Enabled         bool   `yaml:"enabled"`
+	Verbose         bool   `yaml:"verbose"`
 	Host            string `yaml:"host"`
 	Prefix          string `yaml:"prefix"`
 	ClientID        string `yaml:"clientId"`
 	Port            int    `yaml:"port"`
 	SubscriptionQos byte   `yaml:"subscriptionQos"`
 	Persistent      bool   `yaml:"persistent"`
+	Order           bool   `yaml:"order"`
 	SSL             bool   `yaml:"ssl"`
 	Username        string `yaml:"username"`
 	Password        string `yaml:"password"`

--- a/configuration/environment.go
+++ b/configuration/environment.go
@@ -143,6 +143,14 @@ func setEnvironmentMQTTSettings(conf *Config) {
 		}
 	}
 
+	gostMQTTVerbose := os.Getenv("GOST_MQTT_VERBOSE")
+	if gostMQTTVerbose != "" {
+		h, err := strconv.ParseBool(gostMQTTVerbose)
+		if err == nil {
+			conf.MQTT.Verbose = h
+		}
+	}
+
 	gostMQTTHost := os.Getenv("GOST_MQTT_HOST")
 	if gostMQTTHost != "" {
 		conf.MQTT.Host = gostMQTTHost
@@ -180,6 +188,14 @@ func setEnvironmentMQTTSettings(conf *Config) {
 		persistent, err := strconv.ParseBool(gostMQTTPersistent)
 		if err == nil {
 			conf.MQTT.Persistent = persistent
+		}
+	}
+
+	gostMQTTOrder := os.Getenv("GOST_MQTT_ORDER_MATTERS")
+	if gostMQTTOrder != "" {
+		order, err := strconv.ParseBool(gostMQTTOrder)
+		if err == nil {
+			conf.MQTT.Order = order
 		}
 	}
 

--- a/mqtt/mqtt.go
+++ b/mqtt/mqtt.go
@@ -33,19 +33,28 @@ type MQTT struct {
 	pingTimeoutSec	int
 	subscriptionQos byte
 	persistent      bool
+	order           bool
 	connecting      bool
 	disconnected    bool
 	client          paho.Client
+	verbose         bool
 	api             *models.API
 }
 
-func setupLogger() {
+func setupLogger(verbose bool) {
 	l, err := gostLog.GetLoggerInstance()
 	if err != nil {
 		log.Error(err)
 	}
 
 	logger = l.WithFields(log.Fields{"package": "gost.server.mqtt"})
+
+	if verbose {
+		paho.ERROR = logger
+		paho.CRITICAL = logger
+		paho.WARN = logger
+		paho.DEBUG = logger
+	}
 }
 
 func (m *MQTT) getProtocol() string {
@@ -99,6 +108,7 @@ func initMQTTClientOptions(client *MQTT) (*paho.ClientOptions, error) {
 
 	opts.SetClientID(client.clientID)
 	opts.SetCleanSession(!client.persistent)
+	opts.SetOrderMatters(client.order)
 	opts.SetKeepAlive(time.Duration(client.keepAliveSec) * time.Second)
 	opts.SetPingTimeout(time.Duration(client.pingTimeoutSec) * time.Second)
 	opts.SetAutoReconnect(true)
@@ -109,7 +119,7 @@ func initMQTTClientOptions(client *MQTT) (*paho.ClientOptions, error) {
 
 // CreateMQTTClient creates a new MQTT client
 func CreateMQTTClient(config configuration.MQTTConfig) models.MQTTClient {
-	setupLogger()
+	setupLogger(config.Verbose)
 
 	mqttClient := &MQTT{
 		host:            config.Host,
@@ -118,6 +128,7 @@ func CreateMQTTClient(config configuration.MQTTConfig) models.MQTTClient {
 		clientID:        config.ClientID,
 		subscriptionQos: config.SubscriptionQos,
 		persistent:      config.Persistent,
+		order:           config.Order,
 		sslEnabled:      config.SSL,
 		username:        config.Username,
 		password:        config.Password,
@@ -142,8 +153,8 @@ func CreateMQTTClient(config configuration.MQTTConfig) models.MQTTClient {
 // Start running the MQTT client
 func (m *MQTT) Start(api *models.API) {
 	m.api = api
-	logger.Infof("Starting MQTT client on %s://%s:%v with Prefix:%v, Persistence:%v, keep ALive:%v, PingTimeout:%v, QOS:%v",
-		m.getProtocol(), m.host, m.port,m.prefix,m.persistent,m.keepAliveSec,m.pingTimeoutSec,m.subscriptionQos )
+	logger.Infof("Starting MQTT client on %s://%s:%v with Prefix:%v, Persistence:%v, OrderMatters:%v, KeepAlive:%v, PingTimeout:%v, QOS:%v",
+		m.getProtocol(), m.host, m.port,m.prefix,m.persistent,m.order,m.keepAliveSec,m.pingTimeoutSec,m.subscriptionQos )
 	m.connect()
 }
 


### PR DESCRIPTION
Hi all,

we had some issues with GOST server´s Paho client disconnecting from Mosquitto MQTT broker. The client sent a ping request to Mosquitto that was immediately answered with a ping response. This response was never acknowledged  by the Paho client though and the connection ended with:

`MQTT client lost connection: pingresp not received, disconnecting`

The same issue is discussed briefly here: https://github.com/eclipse/paho.mqtt.golang/issues/210

The problem can be solved by setting the Paho client´s "Order" option to false (if message order is irrelevant for your application). So I made this option configurable in GOST server.

During the analysis I switched to Paho´s latest released version 1.1.1 and made the client´s debug logging configurable. Maybe this is also helpful for other MQTT issues.

Please get back to me with any questions or comments.

Best regards

Jannis





